### PR TITLE
Added support for properties of type DateTime

### DIFF
--- a/FSharp.Azure.Storage/Utilities.fs
+++ b/FSharp.Azure.Storage/Utilities.fs
@@ -69,6 +69,7 @@ module internal Utilities =
         | :? (byte[] option) as opt -> opt.Value :> obj
         | :? (bool option) as opt -> opt.Value :> obj
         | :? (DateTimeOffset option) as opt -> opt.Value :> obj
+        | :? (DateTime option) as opt -> opt.Value :> obj
         | :? (double option) as opt -> opt.Value :> obj
         | :? (Guid option) as opt -> opt.Value :> obj
         | :? (int option) as opt -> opt.Value :> obj
@@ -82,6 +83,7 @@ module internal Utilities =
             | :? (byte[]) as v -> Some v :> obj
             | :? bool as v -> Some v :> obj
             | :? DateTimeOffset as v -> Some v :> obj
+            | :? DateTime as v -> Some v :> obj
             | :? double as v -> Some v :> obj
             | :? Guid as v -> Some v :> obj
             | :? int as v -> Some v :> obj


### PR DESCRIPTION
Fixes #12.

This scenario was never previously supported as the Table Storage API looked like it only supported DateTimeOffset. However, it turns out that all it does it convert the datetime to UTC and save it (ie. the offsets are normalized away to UTC), which makes it compatible with usages of DateTime.

I've added the necessary slight munging to get it to work in this PR.

