### PR TITLE
Parameterize connection strings in integration tests. Set up testing for AppVeyor and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: csharp
+
+install:
+
+
+script: 
+  - ./build.sh Default -ef RunRemoteTests

--- a/FSharp.Azure.Storage.sln
+++ b/FSharp.Azure.Storage.sln
@@ -16,6 +16,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.Azure.Storage.Integr
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "project", "project", "{96357C73-EBCB-425F-A39A-D511E8BDBCEA}"
 	ProjectSection(SolutionItems) = preProject
+		.travis.yml = .travis.yml
+		appveyor.yml = appveyor.yml
 		build.cmd = build.cmd
 		build.fsx = build.fsx
 		build.sh = build.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,8 @@
+version: 0.0.1.{build}
+
+configuration: Release
+
+test:
+  categories:
+    except:
+	  - "Emulator"

--- a/build.fsx
+++ b/build.fsx
@@ -25,6 +25,9 @@ let gitHome = "https://github.com/" + gitOwner
 let gitName = "FSharp.Azure.Storage"
 let gitRaw = environVarOrDefault "gitRaw" "https://raw.github.com/" + gitOwner
 
+let remoteTests = environVarOrDefault "RunRemoteTests" "false" |> Boolean.Parse
+let emulatorTests = environVarOrDefault "RunEmulatorTests" "false" |> Boolean.Parse
+
 //
 //// --------------------------------------------------------------------------------------
 //// The rest of the code is standard F# build script 
@@ -90,6 +93,11 @@ Target "RunTests" (fun _ ->
     |> xUnit2 (fun (p : XUnit2Params) -> 
         { p with
             TimeOut = TimeSpan.FromMinutes 20.
+            Parallel = ParallelMode.NoParallelization
+            ExcludeTraits = 
+                [ if not emulatorTests then yield ("Category", "Emulator")
+                  if not remoteTests then yield ("Category", "Remote") ]
+
             HtmlOutputPath = Some "xunit.html"})
 )
 


### PR DESCRIPTION
This PR parameterizes connection string inputs for the integration tests. This allows us to run the same test suite both with the storage emulator and an actual storage account. From FAKE,
```
./build.sh -ef RunEmulatorTests -ef RunRemoteTests
```
In order to get the latter category up and running, the environment variable `FSharpAzureStorageConnectionString` must be set to a working azure storage connection string. This can be then used to set up testing in both AppVeyor and Travis. I have also included travis and appveyor configuration files in the repo.