### PR TITLE
AppVeyor builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ UpgradeLog*.XML
 .fake/
 .paket-files/
 xunit.html
+paket-files/

--- a/FSharp.Azure.Storage/AssemblyInfo.fs
+++ b/FSharp.Azure.Storage/AssemblyInfo.fs
@@ -5,11 +5,11 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyTitleAttribute("FSharp.Azure.Storage")>]
 [<assembly: AssemblyProductAttribute("FSharp.Azure.Storage")>]
 [<assembly: AssemblyCompanyAttribute("Daniel Chambers & Contributors")>]
-[<assembly: AssemblyCopyrightAttribute("Copyright © Daniel Chambers & Contributors 2015")>]
-[<assembly: AssemblyVersionAttribute("2.1.0")>]
-[<assembly: AssemblyFileVersionAttribute("2.1.0")>]
+[<assembly: AssemblyCopyrightAttribute("Copyright © Daniel Chambers & Contributors 2016")>]
+[<assembly: AssemblyVersionAttribute("2.2.0")>]
+[<assembly: AssemblyFileVersionAttribute("2.2.0")>]
 [<assembly: InternalsVisibleToAttribute("FSharp.Azure.Storage.IntegrationTests")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.1.0"
+    let [<Literal>] Version = "2.2.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 2.2.0
+* TBD
+
 ### 2.1.0
 * DateTime can now be used as a type for properties.
 * Renamed project from FSharp.Azure to FSharp.Azure.Storage.

--- a/Readme.md
+++ b/Readme.md
@@ -89,11 +89,18 @@ For further documentation and examples, please visit the [wiki][2].
 [2]: https://github.com/fsprojects/FSharp.Azure.Storage/wiki
 
 
-Dependencies
-------------
-* F# 3.1 (VS2013)
-* WindowsAzure.Storage v3.1.0.1 - Azure SDK v2.3+ required if you want to use the Storage Emulator
-* FSharp.PowerPack v3.0.0
+Building
+--------
+Run `build.cmd` or `build.sh` to restore the required dependencies using Paket and then build 
+and run tests using FAKE. You can also build in Visual Studio.
+
+In order to run integration tests against the Storage Emulator, pass the `-ef RunEmulatorTests`
+arguments to the build script. To run integration tests against a real storage account, set the
+`FSharpAzureStorageConnectionString` environment variable to a Azure Storage account connection
+string, then pass the `-ef RunRemoteTests` arguments to the build script.
+
+**AppVeyor (Windows)**  
+[![Build status](https://ci.appveyor.com/api/projects/status/ssbhpme5jromcbmo?svg=true)](https://ci.appveyor.com/project/daniel-chambers/fsharp-azure-storage) 
 
 ## Maintainer(s)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ version: 2.2.0.{build}
 configuration: Release
 
 build_script:
-	- cmd: build.cmd -ef RunRemoteTests
+  - cmd: build.cmd -ef RunRemoteTests
 
 test: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,12 @@
-version: 0.0.1.{build}
+version: 2.2.0.{build}
 
 configuration: Release
 
-test:
-  categories:
-    except:
-	  - "Emulator"
+build_script:
+	- cmd: build.cmd -ef RunRemoteTests
+
+test: off
+
+environment:
+  FSharpAzureStorageConnectionString:
+    secure: saFGdmViFU9yF3vNqonOY3deDHBkMvgI9OYOGP7Z3InBi8bu78K6Xthr6f7YEiL2VP2B/jN09WmGst38hNv9JUDErf1ocd5uZ1i77Q74pFEstEzDAu8YheP2bZa8Sgso+wwx+SXs9Zgrf/7N2xrWqy/Tep2wrSuUwHRZV2K4+ZhkqbL2+gDsPGPuu88Pqcg580WI+yAo4T3ghjxauaoZJX1LXPlnLgpdReSCVT88cvo=

--- a/build.fsx
+++ b/build.fsx
@@ -51,7 +51,7 @@ Target "AssemblyInfo" (fun _ ->
             Attribute.Title project
             Attribute.Product project
             Attribute.Company "Daniel Chambers & Contributors"
-            Attribute.Copyright "Copyright \169 Daniel Chambers & Contributors 2015"
+            Attribute.Copyright "Copyright \169 Daniel Chambers & Contributors 2016"
             Attribute.Version release.AssemblyVersion
             Attribute.FileVersion release.AssemblyVersion
             Attribute.InternalsVisibleTo "FSharp.Azure.Storage.IntegrationTests"


### PR DESCRIPTION
This PR adds AppVeyor support and extends the initial work done in #18.

AppVeyor runs `build.cmd` the same as a developer would. Integration tests are run against a remote storage account in my Azure subscription. The connection string is encrypted and therefore PR builds are turned off so that the connection string is not exposed to the public (see comments [here][1] for more info).

I've also bumped the version to 2.2 so we can start adding new features to a legit place in the release notes.

[1]:https://github.com/fsprojects/FSharp.Azure.Storage/pull/18#issuecomment-170887648