### PR TITLE
First class support URI

### DIFF
--- a/src/FSharp.Azure.Storage/Table.fs
+++ b/src/FSharp.Azure.Storage/Table.fs
@@ -97,6 +97,8 @@ module Table =
                         | null -> runtimeGetUncheckedDefault f.PropertyType
                         | value when value.GetType() = typeof<DateTime> && underlyingPropertyType = typeof<DateTimeOffset> ->
                             DateTimeOffset(value :?> DateTime) |> wrapIfOption f.PropertyType
+                        | value when value.GetType() = typeof<string> && underlyingPropertyType = typeof<Uri> -> 
+                            Uri(value :?> string) |> wrapIfOption f.PropertyType
                         | value when value.GetType() <> underlyingPropertyType ->
                             failwithf "The property %s on type %s of type %s has deserialized as the incorrect type %s" f.Name typeof<'T>.Name f.PropertyType.Name (value.GetType().Name)
                         | value -> value |> wrapIfOption f.PropertyType
@@ -301,6 +303,8 @@ module Table =
             | :? (int option) as v -> TableQuery.GenerateFilterConditionForInt (propertyName, op |> toOperator, v.Value)
             | :? int64 as v -> TableQuery.GenerateFilterConditionForLong (propertyName, op |> toOperator, v)
             | :? (int64 option) as v -> TableQuery.GenerateFilterConditionForLong (propertyName, op |> toOperator, v.Value)
+            | :? Uri as v -> TableQuery.GenerateFilterCondition(propertyName, op |> toOperator, v.ToString())
+            | :? (Uri option) as v -> TableQuery.GenerateFilterCondition(propertyName, op |> toOperator, v.Value.ToString())
             | _ -> failwithf "Unexpected property type %s for property %s" type'.Name propertyName
 
         let private isPropertyComparisonAgainstBool expr =

--- a/src/FSharp.Azure.Storage/Utilities.fs
+++ b/src/FSharp.Azure.Storage/Utilities.fs
@@ -90,6 +90,7 @@ module internal Utilities =
         | :? (double option) as opt -> opt.Value :> obj
         | :? (Guid option) as opt -> opt.Value :> obj
         | :? (int option) as opt -> opt.Value :> obj
+        | :? (Uri option) as opt -> opt.Value :> obj
         | other -> other
 
     let wrapIfOption (t : Type) (o : obj) =
@@ -104,5 +105,6 @@ module internal Utilities =
             | :? double as v -> Some v :> obj
             | :? Guid as v -> Some v :> obj
             | :? int as v -> Some v :> obj
+            | :? Uri as v -> Some v :> obj
             | other -> other
         else o

--- a/test/FSharp.Azure.Storage.Tests/Table/DataQueryTests.fs
+++ b/test/FSharp.Azure.Storage.Tests/Table/DataQueryTests.fs
@@ -422,20 +422,22 @@ let tests connectionString =
                 |> fst
 
             retrievedGame |> Expect.equal "Retrieved game should be correct" game
-            
-            
-        gameTestCase "querying for a record that has option type fields with none value works when filtering by the option-types properties" <| fun ts ->
-                    let game =
-                        { Name = "Transistor"
-                          Platform = "PC"
-                          Developer = "Supergiant Games"
-                          HasMultiplayer = None
-                          Notes = Some "From the same studio that made Bastion" }
-        
-                    let result = game |> Insert |> inTable tableClient ts.Name
-                    result.HttpStatusCode |> Expect.equal "Status code should be 204" 204              
-        
-                    (fun () -> Query.all<GameWithOptions> |> Query.where <@ fun g _ -> g.HasMultiplayer = None && g.Notes = game.Notes @> |> ignore) |> Expect.throwsT<Exception> "Throws exception" 
+
+        gameTestCase "querying for a record and filtering using a None option value is not supported by table storage" <| fun ts ->
+            let game =
+                { Name = "Transistor"
+                  Platform = "PC"
+                  Developer = "Supergiant Games"
+                  HasMultiplayer = None
+                  Notes = Some "From the same studio that made Bastion" }
+
+            let result = game |> Insert |> inTable tableClient ts.Name
+            result.HttpStatusCode |> Expect.equal "Status code should be 204" 204
+
+            (fun () -> Query.all<GameWithOptions>
+                       |> Query.where <@ fun g _ -> g.HasMultiplayer = None && g.Notes = game.Notes @>
+                       |> ignore)
+            |> Expect.throwsT<Exception> "Throws exception"
 
         gameTestCase "querying for a record type that is internal works" <| fun ts ->
             let game =
@@ -472,43 +474,42 @@ let tests connectionString =
                 |> fst
 
             retrievedGame |> Expect.equal "Retrieved game should be correct" game
-            
+
         gameTestCase "querying for a record type with URI works" <| fun ts ->
-                    let game =
-                        { GameWithUri.Name = "Transistor"
-                          Developer = "Supergiant Games"
-                          HasMultiplayer = true 
-                          Website = Uri ("https://example.org")}
-        
-                    let result = game |> Insert |> inTable tableClient ts.Name
-                    result.HttpStatusCode |> Expect.equal "Status code should be 204" 204
-        
-                    let retrievedGame =
-                        Query.all<GameWithUri>
-                        |> Query.where <@ fun _ s -> s.PartitionKey = game.Developer && s.RowKey = game.Name @>
-                        |> ts.FromGameTable
-                        |> Seq.head
-                        |> fst
-        
-                    retrievedGame |> Expect.equal "Retrieved game should be correct" game
-                    
-                    
+            let game =
+                { GameWithUri.Name = "Transistor"
+                  Developer = "Supergiant Games"
+                  HasMultiplayer = true
+                  Website = Uri ("https://example.org")}
+
+            let result = game |> Insert |> inTable tableClient ts.Name
+            result.HttpStatusCode |> Expect.equal "Status code should be 204" 204
+
+            let retrievedGame =
+                Query.all<GameWithUri>
+                |> Query.where <@ fun _ s -> s.PartitionKey = game.Developer && s.RowKey = game.Name @>
+                |> ts.FromGameTable
+                |> Seq.head
+                |> fst
+
+            retrievedGame |> Expect.equal "Retrieved game should be correct" game
+
         gameTestCase "querying for a record type with URI option works" <| fun ts ->
-                    let game =
-                        { GameWithUriOptions.Name = "Transistor"
-                          Developer = "Supergiant Games"
-                          Website = Some (Uri ("https://example.org"))}
-        
-                    let result = game |> Insert |> inTable tableClient ts.Name
-                    result.HttpStatusCode |> Expect.equal "Status code should be 204" 204
-        
-                    let retrievedGame =
-                        Query.all<GameWithUriOptions>
-                        |> Query.where <@ fun _ s -> s.PartitionKey = game.Developer && s.RowKey = game.Name @>
-                        |> ts.FromGameTable
-                        |> Seq.head
-                        |> fst
-        
-                    retrievedGame |> Expect.equal "Retrieved game should be correct" game
+            let game =
+                { GameWithUriOptions.Name = "Transistor"
+                  Developer = "Supergiant Games"
+                  Website = Some (Uri ("https://example.org"))}
+
+            let result = game |> Insert |> inTable tableClient ts.Name
+            result.HttpStatusCode |> Expect.equal "Status code should be 204" 204
+
+            let retrievedGame =
+                Query.all<GameWithUriOptions>
+                |> Query.where <@ fun _ s -> s.PartitionKey = game.Developer && s.RowKey = game.Name @>
+                |> ts.FromGameTable
+                |> Seq.head
+                |> fst
+
+            retrievedGame |> Expect.equal "Retrieved game should be correct" game
 
     ]

--- a/test/FSharp.Azure.Storage.Tests/Table/DataQueryTests.fs
+++ b/test/FSharp.Azure.Storage.Tests/Table/DataQueryTests.fs
@@ -405,6 +405,20 @@ let tests connectionString =
                 |> fst
 
             retrievedGame |> Expect.equal "Retrieved game should be correct" game
+            
+            
+        gameTestCase "querying for a record that has option type fields with none value works when filtering by the option-types properties" <| fun ts ->
+                    let game =
+                        { Name = "Transistor"
+                          Platform = "PC"
+                          Developer = "Supergiant Games"
+                          HasMultiplayer = None
+                          Notes = Some "From the same studio that made Bastion" }
+        
+                    let result = game |> Insert |> inTable tableClient ts.Name
+                    result.HttpStatusCode |> Expect.equal "Status code should be 204" 204              
+        
+                    (fun () -> Query.all<GameWithOptions> |> Query.where <@ fun g _ -> g.HasMultiplayer = None && g.Notes = game.Notes @> |> ignore) |> Expect.throwsT<Exception> "Throws exception" 
 
         gameTestCase "querying for a record type that is internal works" <| fun ts ->
             let game =


### PR DESCRIPTION
Added first class support for URIs. Since the URIs are safe to be represented as a string support for them with string backing fields was added. 

In my use case I have a lot of uris in my domain objects and creating DTOs just for storing URIs as string felt bad. 
