### PR TITLE
Fixed querying using DynamicTableEntity

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 5.0.0
+* Fixed querying using DynamicTableEntity
+
 ### 4.0.0
 * Switched from using the WindowsAzure.Storage package, which is deprecated, to the Microsoft.Azure.Cosmos.Table package. NOTE: This is a breaking change, but simple to fix; just update namespaces (see PR#39) (Thanks @JohnDoeKyrgyz).
 

--- a/src/FSharp.Azure.Storage/Table.fs
+++ b/src/FSharp.Azure.Storage/Table.fs
@@ -211,6 +211,8 @@ module Table =
                 | _ -> None
 
             match typeof<'T> with
+            | t when typeof<DynamicTableEntity>.IsAssignableFrom t ->
+                Set.empty // It's dynamic so we don't know what properties to query for, so query them all
             | t when typeof<ITableEntity>.IsAssignableFrom t ->
                 t.GetProperties()
                 |> Seq.choose getTableEntityProperty


### PR DESCRIPTION
Querying using `DynamicTableEntity` was not working properly as it was trying to use reflection to select the appropriate properties for the query. This PR fixes it so that all properties are returned (appropriate, since it is dynamic).