### PR TITLE
Added fromTableSegmentedAsyncSeq

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 ### 5.0.0
+* New fromTableSegmentedAsyncSeq that returns an AsyncSeq of query segments
 * Fixed querying using DynamicTableEntity
+* Updated to use v5 of Unquote (potentially breaking if you're stuck on v4)
 
 ### 4.0.0
 * Switched from using the WindowsAzure.Storage package, which is deprecated, to the Microsoft.Azure.Cosmos.Table package. NOTE: This is a breaking change, but simple to fix; just update namespaces (see PR#39) (Thanks @JohnDoeKyrgyz).

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,10 +3,11 @@ framework: auto-detect
 storage: none
 
 //Main deps
+nuget FSharp.Control.AsyncSeq ~> 2.0
 nuget FSharp.Core >= 4.1
-nuget TaskBuilder.fs >= 2.1.0
-nuget Unquote >= 4.0
 nuget Microsoft.Azure.Cosmos.Table >= 1.0
+nuget TaskBuilder.fs >= 2.1.0
+nuget Unquote >= 5.0
 
 //Testing deps
 nuget Expecto

--- a/paket.lock
+++ b/paket.lock
@@ -5,6 +5,8 @@ NUGET
     Expecto (9.0.2)
       FSharp.Core (>= 4.6)
       Mono.Cecil (>= 0.11.2)
+    FSharp.Control.AsyncSeq (2.0.24)
+      FSharp.Core (>= 4.3.2)
     FSharp.Core (5.0)
     Microsoft.Azure.Cosmos.Table (1.0.8)
       Microsoft.Azure.DocumentDB.Core (>= 2.11.2)

--- a/src/FSharp.Azure.Storage/paket.references
+++ b/src/FSharp.Azure.Storage/paket.references
@@ -1,4 +1,5 @@
+FSharp.Control.AsyncSeq
 FSharp.Core
 Microsoft.Azure.Cosmos.Table
-Unquote
 TaskBuilder.fs
+Unquote


### PR DESCRIPTION
Added a new function `fromTableSegmentedAsyncSeq` which returns an AsyncSeq of segments when querying. This allows one to more easily query a large table without needing to implement looping/recursion yourself when using `fromTableSegmentedAsync`.

Unforatunately, we're stuck on v2 of `FSharp.Control.AsyncSeq` because we target `netstandard2.0` and v3 of `FSharp.Control.AsyncSeq` targets `netstandard2.1`. If this becomes a problem for people, we may need to change our own target up to `netstandard2.0`, but I'm loathe to do that until someone complains because it'll leave all the .NET Framework 4.x people behind.