### PR TITLE
Downgrade FSharp.Core to 4.7

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,7 @@ storage: none
 
 //Main deps
 nuget FSharp.Control.AsyncSeq ~> 2.0
-nuget FSharp.Core >= 4.1
+nuget FSharp.Core >= 4.7
 nuget Microsoft.Azure.Cosmos.Table >= 1.0
 nuget TaskBuilder.fs >= 2.1.0
 nuget Unquote >= 5.0

--- a/paket.lock
+++ b/paket.lock
@@ -7,7 +7,7 @@ NUGET
       Mono.Cecil (>= 0.11.2)
     FSharp.Control.AsyncSeq (2.0.24)
       FSharp.Core (>= 4.3.2)
-    FSharp.Core (5.0)
+    FSharp.Core (4.7)
     Microsoft.Azure.Cosmos.Table (1.0.8)
       Microsoft.Azure.DocumentDB.Core (>= 2.11.2)
       Microsoft.OData.Core (>= 7.6.4)


### PR DESCRIPTION
While FSharp.Azure.Storage ostensibly supports being used with older FSharp.Core assemblies, I had upgraded the build to use 5.0. However, for some reason, when used with a .NET Core 3.1 project referencing FSharp.Core 4.7.2, I am receiving the following exception:

```
Could not load file or assembly 'FSharp.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The located assembly's manifest definition does not match the assembly reference. (0x80131040)\r\nFile name: 'FSharp.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
```

For some reason I don't understand .NET Core's binding redirects do not seem to be taking care of this automatically. So I have downgraded the version we're building with to 4.7.0 in the hopes that this will resolve the problem.